### PR TITLE
fix(group): avoid breaking on some operations when using DataView for group

### DIFF
--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -1364,16 +1364,16 @@ class ItemSet extends Component {
 
       const changed = !util.equalArray(groupIds, this.groupIds);
       if (changed) {
+
+        const groups = groupIds
+          .map(groupId => this.groups[groupId])
+          .filter(group => !!group)
+
         // hide all groups, removes them from the DOM
-        const groups = this.groups;
-        groupIds.forEach(groupId => {
-          groups[groupId].hide();
-        });
+        groups.forEach(group => group.hide())
 
         // show the groups again, attach them to the DOM in correct order
-        groupIds.forEach(groupId => {
-          groups[groupId].show();
-        });
+        groups.forEach(group => group.show())
 
         this.groupIds = groupIds;
       }
@@ -1956,7 +1956,7 @@ class ItemSet extends Component {
       nextLevel = [];
       for (let i = 0; i < current.length; i++) {
         let node = groupsData.get(current[i]);
-        if (node.nestedGroups) {
+        if (node && node.nestedGroups) {
           nextLevel = nextLevel.concat(node.nestedGroups);
         }
       }


### PR DESCRIPTION
With DataView, groups linked to items cannot be retrieved because filtered
out and on some operation (toggle/show group), it can breaks the lookup.
